### PR TITLE
Request to optimize package size by removing `openCollapses.gif`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,5 @@ codeStandard.md
 
 .gitignore
 .yarnrc
+
+**/*.gif


### PR DESCRIPTION
Hello,

I've been using the "Class Collapse" extension for VSCode and found it incredibly useful. However, I noticed that the extension package includes a file named `openCollapses.gif` in the `public` directory, which is approximately 42.5 MB in size. This file seems to have no effect on the functionality of the extension and significantly increases the overall size of the package.

Would it be possible to consider removing this GIF from the packaged extension? This change would help in reducing the download and installation size, making the extension more streamlined and efficient for users.

Additionally, here is a suggestion to prevent this file from being included in the build: You can add the `public/openCollapses.gif` path to the `.vscodeignore` file. This will exclude it from the packaged version of the extension that users download and install.

Thank you for considering this improvement. I look forward to future versions of your extension.