### PR TITLE
[fix] Do not include readme images and gifs in the extensions file size

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -18,4 +18,7 @@ codeStandard.md
 .gitignore
 .yarnrc
 
-**/*.gif
+# these images/gifs are only in the readme and doesn't need to be in the extension
+public/img/Discord.png
+public/img/Ko-fi.png
+public/gif/openCollapses.gif

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -17,3 +17,5 @@ codeStandard.md
 
 .gitignore
 .yarnrc
+
+**/*.gif


### PR DESCRIPTION
```diff
+ public/img/Discord.png
+ public/img/Ko-fi.png
+ public/gif/openCollapses.gif
```